### PR TITLE
ci: add crates.io publish workflow

### DIFF
--- a/.github/workflows/crates.yml
+++ b/.github/workflows/crates.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Automate crates.io publishing when version tags are pushed, eliminating manual publish steps and reducing release errors.

Closes #6

## Changes
- Add `.github/workflows/crates.yml` workflow triggered on `v*` tags
- Uses `dtolnay/rust-toolchain@stable` for Rust setup
- Publishes via `cargo publish` with `CARGO_REGISTRY_TOKEN` secret

## Testing
Workflow matches proven pattern from boha and vuke repositories.

---
Co-Authored-By: Aei <aei@oad.earth>