### PR TITLE
perf: parallel batch inversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /pkg
 /src/kangaroo-*/
+/.sisyphus/


### PR DESCRIPTION
## Summary

Replaces serial Montgomery's trick with full parallel Blelloch scan algorithm for batch inversion in GPU shader. Achieves 42-57% performance improvement across all range sizes by utilizing all 64 threads instead of leaving 63 idle.

Closes #19

## Changes

- **Parallel prefix scan**: 6-step up-sweep + 6-step down-sweep for exclusive prefix products
- **Parallel suffix scan**: Same algorithm on reversed array for exclusive suffix products  
- **Parallel final computation**: All threads compute `inv[i] = inv_total × prefix[i] × suffix[i]`
- **Correctness fix**: Skip affine addition when `dx==0` (point collision) instead of performing invalid group operation
- **Code clarity**: Improved comments for stride-32 up-sweep step

## Performance Results

| Range  | Before    | After     | Improvement |
|--------|-----------|-----------|-------------|
| 32-bit | 2.95 M/s  | 4.20 M/s  | +42%        |
| 40-bit | 4.97 M/s  | 7.58 M/s  | +52%        |
| 48-bit | 5.58 M/s  | 8.75 M/s  | +57%        |

## Testing

- Smoke test passes: Puzzle 20 solved in 35.24s
- Full benchmark suite validates performance gains
- Oracle code review completed (11m 47s deep analysis)
- All correctness issues from review addressed

---
Co-Authored-By: Aei <aei@oad.earth>