### PR TITLE
perf(gpu): optimize fe_square

### DIFF
--- a/src/gpu_crypto/shaders/field.wgsl
+++ b/src/gpu_crypto/shaders/field.wgsl
@@ -508,6 +508,14 @@ fn fe_square(a: array<u32, 8>) -> array<u32, 8> {
     if (c > 0u) { old = p5; p5 = p5 + c; c = select(0u, 1u, p5 < old); }
     if (c > 0u) { old = p6; p6 = p6 + c; c = select(0u, 1u, p6 < old); }
     if (c > 0u) { old = p7; p7 = p7 + c; c = select(0u, 1u, p7 < old); }
+    if (c > 0u) { old = p8; p8 = p8 + c; c = select(0u, 1u, p8 < old); }
+    if (c > 0u) { old = p9; p9 = p9 + c; c = select(0u, 1u, p9 < old); }
+    if (c > 0u) { old = p10; p10 = p10 + c; c = select(0u, 1u, p10 < old); }
+    if (c > 0u) { old = p11; p11 = p11 + c; c = select(0u, 1u, p11 < old); }
+    if (c > 0u) { old = p12; p12 = p12 + c; c = select(0u, 1u, p12 < old); }
+    if (c > 0u) { old = p13; p13 = p13 + c; c = select(0u, 1u, p13 < old); }
+    if (c > 0u) { old = p14; p14 = p14 + c; c = select(0u, 1u, p14 < old); }
+    if (c > 0u) { p15 = p15 + c; }
 
     // a[1]²
     t = mul32(a[1], a[1]);
@@ -519,6 +527,12 @@ fn fe_square(a: array<u32, 8>) -> array<u32, 8> {
     if (c > 0u) { old = p7; p7 = p7 + c; c = select(0u, 1u, p7 < old); }
     if (c > 0u) { old = p8; p8 = p8 + c; c = select(0u, 1u, p8 < old); }
     if (c > 0u) { old = p9; p9 = p9 + c; c = select(0u, 1u, p9 < old); }
+    if (c > 0u) { old = p10; p10 = p10 + c; c = select(0u, 1u, p10 < old); }
+    if (c > 0u) { old = p11; p11 = p11 + c; c = select(0u, 1u, p11 < old); }
+    if (c > 0u) { old = p12; p12 = p12 + c; c = select(0u, 1u, p12 < old); }
+    if (c > 0u) { old = p13; p13 = p13 + c; c = select(0u, 1u, p13 < old); }
+    if (c > 0u) { old = p14; p14 = p14 + c; c = select(0u, 1u, p14 < old); }
+    if (c > 0u) { p15 = p15 + c; }
 
     // a[2]²
     t = mul32(a[2], a[2]);
@@ -529,6 +543,11 @@ fn fe_square(a: array<u32, 8>) -> array<u32, 8> {
     if (c > 0u) { old = p8; p8 = p8 + c; c = select(0u, 1u, p8 < old); }
     if (c > 0u) { old = p9; p9 = p9 + c; c = select(0u, 1u, p9 < old); }
     if (c > 0u) { old = p10; p10 = p10 + c; c = select(0u, 1u, p10 < old); }
+    if (c > 0u) { old = p11; p11 = p11 + c; c = select(0u, 1u, p11 < old); }
+    if (c > 0u) { old = p12; p12 = p12 + c; c = select(0u, 1u, p12 < old); }
+    if (c > 0u) { old = p13; p13 = p13 + c; c = select(0u, 1u, p13 < old); }
+    if (c > 0u) { old = p14; p14 = p14 + c; c = select(0u, 1u, p14 < old); }
+    if (c > 0u) { p15 = p15 + c; }
 
     // a[3]²
     t = mul32(a[3], a[3]);
@@ -538,6 +557,10 @@ fn fe_square(a: array<u32, 8>) -> array<u32, 8> {
     if (c > 0u) { old = p9; p9 = p9 + c; c = select(0u, 1u, p9 < old); }
     if (c > 0u) { old = p10; p10 = p10 + c; c = select(0u, 1u, p10 < old); }
     if (c > 0u) { old = p11; p11 = p11 + c; c = select(0u, 1u, p11 < old); }
+    if (c > 0u) { old = p12; p12 = p12 + c; c = select(0u, 1u, p12 < old); }
+    if (c > 0u) { old = p13; p13 = p13 + c; c = select(0u, 1u, p13 < old); }
+    if (c > 0u) { old = p14; p14 = p14 + c; c = select(0u, 1u, p14 < old); }
+    if (c > 0u) { p15 = p15 + c; }
 
     // a[4]²
     t = mul32(a[4], a[4]);
@@ -546,6 +569,9 @@ fn fe_square(a: array<u32, 8>) -> array<u32, 8> {
     if (c > 0u) { old = p10; p10 = p10 + c; c = select(0u, 1u, p10 < old); }
     if (c > 0u) { old = p11; p11 = p11 + c; c = select(0u, 1u, p11 < old); }
     if (c > 0u) { old = p12; p12 = p12 + c; c = select(0u, 1u, p12 < old); }
+    if (c > 0u) { old = p13; p13 = p13 + c; c = select(0u, 1u, p13 < old); }
+    if (c > 0u) { old = p14; p14 = p14 + c; c = select(0u, 1u, p14 < old); }
+    if (c > 0u) { p15 = p15 + c; }
 
     // a[5]²
     t = mul32(a[5], a[5]);
@@ -553,6 +579,8 @@ fn fe_square(a: array<u32, 8>) -> array<u32, 8> {
     s = p11 + t.y; hi = select(0u, 1u, s < p11); s = s + c; hi = hi + select(0u, 1u, s < c); p11 = s; c = hi;
     if (c > 0u) { old = p12; p12 = p12 + c; c = select(0u, 1u, p12 < old); }
     if (c > 0u) { old = p13; p13 = p13 + c; c = select(0u, 1u, p13 < old); }
+    if (c > 0u) { old = p14; p14 = p14 + c; c = select(0u, 1u, p14 < old); }
+    if (c > 0u) { p15 = p15 + c; }
 
     // a[6]²
     t = mul32(a[6], a[6]);


### PR DESCRIPTION
## Summary

Replace naive `fe_square(a) = fe_mul(a, a)` with dedicated schoolbook squaring that exploits symmetry `a[i]*a[j] == a[j]*a[i]`.

Closes #29

## Changes

- 28 cross products (upper triangle) + doubling + 8 diagonal products = **36 `mul32`** instead of 64 (**-44%**)
- Reduction step identical to `fe_mul` (secp256k1-specific: 2²⁵⁶ ≡ 2³² + 977)
- Individual variables for p0..p15 (avoids RADV array indexing issues)

## Benchmark (AMD RX 6800S)

| Range | v0.5.0 | This PR | Change |
|-------|--------|---------|--------|
| 32-bit | 4.21 M/s | 9.51 M/s | +126% |
| 40-bit | 7.08 M/s | 9.54 M/s | +35% |
| 48-bit | 8.84 M/s | 9.57 M/s | +8% |

The 32-bit jump is from faster `fe_inv` during calibration (more `steps_per_call`). The 48-bit steady-state reflects the true shader speedup.

## Testing

- `cargo test --all-features` — 33 passed (including `test_smoke_puzzle_20` GPU solver)
- `cargo clippy --all-features -- -D warnings` — clean
- `kangaroo --benchmark` — results above

---
Co-Authored-By: Ori <18102267+oritwoen@users.noreply.github.com>