### PR TITLE
fix(solver): stabilize tiny-range boha

### DIFF
--- a/src/cpu/init.rs
+++ b/src/cpu/init.rs
@@ -163,7 +163,7 @@ pub fn initialize_kangaroos(
 
     // Grid delta for even distribution (S2 strategy)
     let grid_delta = if num_kangaroos > 0 {
-        range_size / (num_kangaroos as u128)
+        (range_size / (num_kangaroos as u128)).max(1)
     } else {
         range_size
     };
@@ -185,7 +185,8 @@ pub fn initialize_kangaroos(
             // Grid-based offset + small random jitter
             let grid_pos = (i as u128) * grid_delta;
             let prng_seed = hash_seed(i, 0xCAFEBABE);
-            let jitter = prng_seed % (grid_delta / 2 + 1);
+            let jitter_span = (grid_delta / 2).max(1);
+            let jitter = prng_seed % jitter_span;
 
             let offset = (grid_pos + jitter) % range_size;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -525,7 +525,19 @@ pub fn run(args: Args) -> anyhow::Result<()> {
         info!("Compute units: {}", gpu_context.compute_units());
     }
 
-    let num_k = args.kangaroos.unwrap_or(gpu_context.optimal_kangaroos());
+    let requested_num_k = args.kangaroos.unwrap_or(gpu_context.optimal_kangaroos());
+    let max_k_for_range = if effective_range >= 32 {
+        u32::MAX
+    } else {
+        (1u32 << effective_range).max(3)
+    };
+    let num_k = requested_num_k.min(max_k_for_range);
+    if !args.quiet && !args.json && num_k != requested_num_k {
+        info!(
+            "Capping kangaroos from {} to {} for {}-bit range",
+            requested_num_k, num_k, effective_range
+        );
+    }
     let dp_bits = args.dp_bits.map(|v| v.clamp(8, 40)).unwrap_or_else(|| {
         let auto_dp = (effective_range / 2).saturating_sub((num_k as f64).log2() as u32 / 2);
         auto_dp.clamp(8, 40)


### PR DESCRIPTION
## Summary
Prevented tiny-range boha targets from stalling by capping auto walker count to effective range size and hardening start distribution jitter/grid math.

Closes #63

## Changes
- Cap auto-selected `kangaroos` in `src/lib.rs` for small effective ranges
- Add safe lower bounds for `grid_delta` and jitter span in `src/cpu/init.rs`
- Preserve existing behavior for larger ranges

## Testing
- `cargo run --release --features boha -- --target boha:b1000/10 --max-ops 50000000`
- `cargo run --release --features boha -- --target boha:b1000/20 --max-ops 50000000`
- `cargo test --features boha`

---
Co-Authored-By: Ori <18102267+oritwoen@users.noreply.github.com>