### PR TITLE
fix(provider): allow exact-fit search ranges for provider bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ kangaroo --pubkey <PUBKEY> --start <START> --range <BITS>
 | `-t, --target` | - | Data provider target (e.g., `boha:b1000/135`) |
 | `-p, --pubkey` | - | Target public key (compressed hex, 33 bytes) |
 | `-s, --start` | 0 | Start of search range (hex, without 0x prefix) |
-| `-r, --range` | 32 | Search range in bits (key is in [start, start + 2^range]) |
+| `-r, --range` | 32 | Search range in bits (key is in [start, start + 2^range - 1]) |
 | `-d, --dp-bits` | auto | Distinguished point bits |
 | `-k, --kangaroos` | auto | Number of parallel kangaroos |
 | `--gpu` | 0 | GPU device index |

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ use tracing::{error, info};
 
 /// Pollard's Kangaroo ECDLP solver for secp256k1
 ///
-/// Finds private key k such that P = k*G, given that k is in range [start, start + 2^range_bits]
+/// Finds private key k such that P = k*G, given that k is in range [start, start + 2^range_bits - 1]
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 pub struct Args {
@@ -56,7 +56,7 @@ pub struct Args {
     #[arg(short, long)]
     start: Option<String>,
 
-    /// Bit range to search (key is in [start, start + 2^range])
+    /// Bit range to search (key is in [start, start + 2^range - 1])
     #[arg(short, long)]
     range: Option<u32>,
 
@@ -306,7 +306,7 @@ fn validate_search_bounds(
         ));
     }
 
-    let search_end = &start_val + (BigUint::from(1u64) << range_bits);
+    let search_end = &start_val + (BigUint::from(1u64) << range_bits) - BigUint::from(1u32);
     if search_end > provider_end_val {
         return Err(anyhow!(
             "Search range [0x{}..0x{:x}] exceeds puzzle '{}' maximum 0x{}",
@@ -1403,10 +1403,14 @@ mod tests {
 
     #[test]
     fn test_validate_search_bounds_exact_fit() {
-        // Range [0x20..., 0x40...) is exactly 2^65 wide
-        // Starting at 0x20... with range 65 bits should fit exactly
         let pr = make_provider_result("20000000000000000", "40000000000000000");
         assert!(validate_search_bounds("20000000000000000", 65, &pr).is_ok());
+    }
+
+    #[test]
+    fn test_validate_search_bounds_exact_fit_8_bit_inclusive() {
+        let pr = make_provider_result("0", "ff");
+        assert!(validate_search_bounds("0", 8, &pr).is_ok());
     }
 }
 


### PR DESCRIPTION
Closes #73.

Provider-backed ranges are treated as inclusive in the rest of the code, but `validate_search_bounds` was effectively checking with an exclusive upper bound. That rejected exact-fit cases like `[0x00..0xff]` with `--range 8`.

This updates the bound check to use the inclusive end (`start + 2^range - 1`), adds a regression test for the 8-bit exact-fit case, and aligns the CLI docs with the actual range semantics.