### PR TITLE
fix(cli): make benchmark dispatch explicit

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -456,10 +456,8 @@ fn resolve_backend_and_local_index(
     let backend = gpu_crypto::GpuBackend::from_wgpu_backend(selected.backend);
     let local_index = gpu_devices
         .iter()
-        .filter(|d| {
-            d.index < selected_global_index
-                && gpu_crypto::GpuBackend::from_wgpu_backend(d.backend) == backend
-        })
+        .take_while(|d| d.index != selected_global_index)
+        .filter(|d| gpu_crypto::GpuBackend::from_wgpu_backend(d.backend) == backend)
         .count() as u32;
 
     (backend, local_index)
@@ -1698,5 +1696,19 @@ mod cli_tests {
             resolve_backend_and_local_index(5, &devices, gpu_crypto::GpuBackend::Dx12);
         assert_eq!(backend, gpu_crypto::GpuBackend::Dx12);
         assert_eq!(local, 5);
+    }
+
+    #[test]
+    fn test_resolve_backend_and_local_index_uses_slice_order_not_numeric_index() {
+        let devices = vec![
+            mk_gpu_backend(10, wgpu::DeviceType::DiscreteGpu, wgpu::Backend::Vulkan),
+            mk_gpu_backend(2, wgpu::DeviceType::DiscreteGpu, wgpu::Backend::Metal),
+            mk_gpu_backend(30, wgpu::DeviceType::IntegratedGpu, wgpu::Backend::Vulkan),
+        ];
+
+        let (backend, local) =
+            resolve_backend_and_local_index(30, &devices, gpu_crypto::GpuBackend::Auto);
+        assert_eq!(backend, gpu_crypto::GpuBackend::Vulkan);
+        assert_eq!(local, 1);
     }
 }


### PR DESCRIPTION
## **User description**
Closes #74

I was validating benchmark flag behavior and noticed the benchmark path was mixed into the solve flow. This makes `--cpu --benchmark` behave unpredictably and also forces solve params before benchmark dispatch.

This change makes benchmark handling explicit at the top of `run()`:
- benchmark mode runs before solve parameter resolution
- `--cpu --benchmark` now returns a clear error instead of silently taking a different path
- added a regression test for the mixed-flag case

Verification run locally:
- `cargo fmt`
- `cargo test --lib test_cli_cpu_benchmark_combo_returns_clear_error`
- `cargo test --lib`
- `cargo clippy --all-features -- -D warnings`
- `cargo build --release --all-features`
- `cubic review -p \"Focus on real bugs, security issues, logic errors, type safety problems, and missed edge cases. Skip cosmetic nits and formatting that linters handle. Be direct and specific: what is wrong, where, and why it matters. No filler, no praise, no generic advice.\"`
- `coderabbit review --plain --type uncommitted`


___

## **CodeAnt-AI Description**
Make benchmark mode explicit, validate GPU selection, and add tests

### What Changed
- Running with --benchmark now dispatches benchmark mode before solving and returns an explicit error if used with --cpu
- Benchmark selection derives the GPU backend from the selected device and maps the global GPU index to the backend-local index so the intended GPU and backend are used
- Benchmark mode enforces a single-GPU selection and rejects multi-GPU requests with a clear message
- Added tests to cover the --cpu + --benchmark error and the backend/local-index mapping behavior

### Impact
`✅ Clearer error when running --cpu with --benchmark`
`✅ Correct GPU and backend used for benchmarks`
`✅ Fewer benchmark misconfigurations`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
